### PR TITLE
fix: add repository metadata

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -9,5 +9,6 @@
       "tokenize": "src/tokenizePerl.js",
       "firstLine": "^#!.*\\bperl\\b"
     }
-  ]
+  ],
+  "repository": "https://github.com/lvce-editor/language-basics-perl"
 }


### PR DESCRIPTION
Adds the canonical GitHub repository URL to extension.json so the extension details view can link to the package source.